### PR TITLE
don't use `default-config.toml` as configuration file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,10 @@ The configuration file location is `~/.config/eilmeldung/config.toml` (Linux) or
 
 **Note:** Icons and special characters require a terminal and font that support [Nerd Fonts](https://www.nerdfonts.com/).
 
-You can find the default configuration in `examples/default-config.toml`
+
+ **Important**: You don't need a `config.toml` file. If you don't provide your own `config.toml` *eilmeldung* uses sensible defaults. If you are interested in what these defaults are, you can consult `examples/default-config.toml`.
+
+ **Note**: You should not use `examples/default-config.toml` as your configuration as this will cause breaking changes with future releases. Start with an empty `config.toml` and add all the settings you want to have *different* from the default configuration.
 
 ---
 


### PR DESCRIPTION
Clarified usage of config.toml and advised against using default config.