### PR TITLE
feat: Support the `nextunread` command in feed list

### DIFF
--- a/src/messages/command/mod.rs
+++ b/src/messages/command/mod.rs
@@ -267,6 +267,13 @@ pub enum Command {
     NavigateRight,
 
     #[strum(
+        serialize = "nextunread",
+        message = "nextunread",
+        detailed_message = "select next unread item (feed list, article list)"
+    )]
+    SelectNextUnread,
+
+    #[strum(
         serialize = "_search",
         message = "_search",
         detailed_message = "open prompt to search"
@@ -517,13 +524,6 @@ pub enum Command {
     TagAdd(String, Option<Color>),
 
     // article list commands
-    #[strum(
-        serialize = "nextunread",
-        message = "nextunread",
-        detailed_message = "selected next unread item (article list)"
-    )]
-    ArticleListSelectNextUnread,
-
     #[strum(
         serialize = "show",
         message = "show <article scope>",
@@ -783,7 +783,7 @@ impl Display for Command {
                 write!(f, "change color of tag to {}", color)
             }
             FeedListSort => write!(f, "sort feed list alphabetically"),
-            ArticleListSelectNextUnread => write!(f, "select next unread"),
+            SelectNextUnread => write!(f, "select next unread"),
             Show(ArticleScope::Marked) => write!(f, "show only marked"),
             Show(ArticleScope::Unread) => write!(f, "show only unread"),
             Show(ArticleScope::All) => write!(f, "show all"),

--- a/src/ui/articles_list/mod.rs
+++ b/src/ui/articles_list/mod.rs
@@ -644,7 +644,7 @@ impl crate::messages::MessageReceiver for ArticlesList {
                         ))))?;
                 }
 
-                C::ArticleListSelectNextUnread => {
+                C::SelectNextUnread if handle_command => {
                     self.select_next_unread()?;
                 }
 

--- a/src/ui/feeds_list/mod.rs
+++ b/src/ui/feeds_list/mod.rs
@@ -597,6 +597,66 @@ impl FeedList {
         Ok(())
     }
 
+    fn item_has_unread(&self, item: &FeedListItem) -> bool {
+        match item {
+            FeedListItem::All => *self.model_data.unread_count_all() > 0,
+            FeedListItem::Feed(feed) => self
+                .model_data
+                .unread_count_for_feed_or_category()
+                .get(&FeedOrCategory::Feed(feed.feed_id.clone()))
+                .map(|count| *count > 0)
+                .unwrap_or(false),
+            FeedListItem::Category(category) => self
+                .model_data
+                .unread_count_for_feed_or_category()
+                .get(&FeedOrCategory::Category(category.category_id.clone()))
+                .map(|count| *count > 0)
+                .unwrap_or(false),
+            FeedListItem::Tag(tag) => self
+                .model_data
+                .unread_count_for_tag()
+                .get(&tag.tag_id)
+                .map(|count| *count > 0)
+                .unwrap_or(false),
+            FeedListItem::Categories | FeedListItem::Tags | FeedListItem::Query(_) => false,
+        }
+    }
+
+    fn select_next_unread(&mut self) -> color_eyre::Result<()> {
+        let selected = self.view_data.tree_state().selected();
+        let paths = self.view_data.paths().to_vec();
+
+        // find the current or next path that has unread items
+        let found_path = paths
+            .iter()
+            .skip_while(|path| **path != selected)
+            .find(|path| {
+                path.last()
+                    .map(|item| self.item_has_unread(item))
+                    .unwrap_or(false)
+            })
+            .cloned();
+
+        if let Some(found_path) = found_path {
+            let parent = found_path.split_last().map(|split| split.1.to_vec());
+
+            if let Some(parent) = parent {
+                self.view_data.tree_state_mut().open(parent);
+            }
+
+            self.view_data.tree_state_mut().select(found_path.to_vec());
+            self.generate_articles_selected_command()?;
+        } else {
+            tooltip(
+                &self.message_sender,
+                "no unread items",
+                TooltipFlavor::Warning,
+            )?;
+        }
+
+        Ok(())
+    }
+
     async fn sort(&self) -> color_eyre::Result<()> {
         self.model_data.sort().await
     }
@@ -672,6 +732,10 @@ impl MessageReceiver for FeedList {
                 }
                 C::NavigateLast if handle_command => {
                     self.view_data.tree_state_mut().select_last();
+                    selection_changed = true;
+                }
+                C::SelectNextUnread if handle_command => {
+                    self.select_next_unread()?;
                     selection_changed = true;
                 }
                 C::FeedListToggleExpand => {


### PR DESCRIPTION
The `nextunread` command was hardcoded to only work on the article list. Now it's a shared navigation command that works on whichever panel is focused - selecting the next unread feed in the feed list, or the next unread article in the article list. Both panels can also be targeted explicitly with `in feeds`/`in articles`.

**Caveat**: The default "o" keybinding sends `open read nextunread` as a batch. Previously the bare `nextunread` always hit the articles list. Now, if the feed list is focused when o is pressed, `nextunread` will navigate to the next unread feed instead. The "r" binding (read then `in articles nextunread`) is unaffected. If you want the old "o" behavior preserved, you'd need to change the binding to use `in articles nextunread` explicitly.
