### PR TITLE
docs: add Windows/PowerShell GPG secrets setup guide

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -631,6 +631,10 @@ Configuration options with type *secret* are strings which
 - either contain the secret itself (e.g, `password = "abcd1234" `); storing password in *clear text* is **NOT RECOMMENDED**
 - or contain a command with prefix `cmd:` which outputs the secret to stdout (e.g., `password = "cmd:pass my-passwords/eilmeldung"`); **THIS IS THE WAY**
 
+For step-by-step examples of setting up secrets for FreshRSS, see:
+- [FreshRSS automatic login with pass (Linux and macOS)](examples/freshrss_secrets_linux_macos.md)
+- [FreshRSS automatic login with GPG (Windows / PowerShell)](examples/freshrss_secrets_windows.md)
+
 ### Finding the Right Settings
 
 `eilmeldung` outputs all needed values via the command line switch `--print-login-data`. If you are already logged in, it simply outputs the login data. If you are not logged in, you will be led through the interactive login process and the login data is output afterwards:

--- a/docs/examples/freshrss_secrets_linux_macos.md
+++ b/docs/examples/freshrss_secrets_linux_macos.md
@@ -1,0 +1,41 @@
+# FreshRSS Automatic Login with pass (Linux and macOS)
+
+This guide shows how to securely store your FreshRSS credentials using [`pass`](https://www.passwordstore.org/), the standard Unix password manager, and use them with eilmeldung's `cmd:` secret feature.
+
+## Install and Setup pass
+
+Install `pass` via your package manager:
+
+```bash
+# Debian/Ubuntu
+apt install pass
+
+# macOS
+brew install pass
+```
+
+Generate a GPG key if you don't have one, then initialize `pass` with it:
+
+```bash
+gpg --gen-key
+pass init "your_email_address"
+```
+
+## Store Your FreshRSS Credentials
+
+```bash
+pass insert eilmeldung/url
+pass insert eilmeldung/user
+pass insert eilmeldung/password
+```
+
+## eilmeldung Config for FreshRSS
+
+```toml
+[login_setup]
+login_type = "direct_password"
+provider = "freshrss"
+url = "cmd:pass eilmeldung/url"
+user = "cmd:pass eilmeldung/user"
+password = "cmd:pass eilmeldung/password"
+```

--- a/docs/examples/freshrss_secrets_windows.md
+++ b/docs/examples/freshrss_secrets_windows.md
@@ -1,0 +1,66 @@
+# FreshRSS Automatic Login with GPG (Windows / PowerShell)
+
+This guide shows how to securely store your FreshRSS credentials using GPG on Windows and use them with eilmeldung's `cmd:` secret feature.
+
+## Install and Setup GPG
+
+```powershell
+# Install gpg but don't run it yet (we need to create the env var first)
+scoop install gpg4win
+
+# Create the GnuPG config directory
+mkdir "$env:USERPROFILE\.config\gnupg" -Force
+
+# Set permissions
+icacls "$env:USERPROFILE\.config\gnupg" /inheritance:r /grant:r "$env:USERNAME`:F"
+
+# Set the GNUPGHOME env var permanently
+[Environment]::SetEnvironmentVariable("GNUPGHOME", "$env:USERPROFILE\.config\gnupg", "User")
+
+# Restart your terminal, then generate a key
+~\scoop\apps\gpg4win\current\GnuPG\bin\gpg.exe --gen-key
+```
+
+## Encrypt Your FreshRSS URL, Username, and Password
+
+```powershell
+mkdir ~/.passwords
+"https://your_freshrss_domain.com" | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-url.gpg"
+"your_freshrss_username" | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"
+"your_api_password" | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"
+```
+
+### Test Decryption
+
+```powershell
+gpg --quiet --decrypt ~/.passwords/eilmeldung-url.gpg
+gpg --quiet --decrypt ~/.passwords/eilmeldung-user.gpg
+gpg --quiet --decrypt ~/.passwords/eilmeldung-pass.gpg
+```
+
+## Create the Retrieval Scripts
+
+```powershell
+New-Item "$env:USERPROFILE\.config\eilmeldung\get-url.ps1" -Force
+New-Item "$env:USERPROFILE\.config\eilmeldung\get-user.ps1" -Force
+New-Item "$env:USERPROFILE\.config\eilmeldung\get-pass.ps1" -Force
+```
+
+Add content to each:
+
+```powershell
+Add-Content "$env:USERPROFILE\.config\eilmeldung\get-url.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-url.gpg"'
+Add-Content "$env:USERPROFILE\.config\eilmeldung\get-user.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"'
+Add-Content "$env:USERPROFILE\.config\eilmeldung\get-pass.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"'
+```
+
+## eilmeldung Config for FreshRSS
+
+```toml
+[login_setup]
+login_type = "direct_password"
+provider = "freshrss"
+url = "cmd:%USERPROFILE%/.config/eilmeldung/get-url.ps1"
+user = "cmd:%USERPROFILE%/.config/eilmeldung/get-user.ps1"
+password = "cmd:%USERPROFILE%/.config/eilmeldung/get-pass.ps1"
+```


### PR DESCRIPTION
## Summary

- Adds a new "Secrets on Windows with PowerShell" subsection under the existing `### Secrets` section in `docs/configuration.md`
- Covers GPG installation via Scoop, key generation, encrypting FreshRSS credentials, and creating retrieval scripts
- Includes the corresponding `[login_setup]` config snippet for using the scripts as `cmd:` secrets