### PR TITLE
Windows: add build/install scripts and documentation for cargo builds

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,10 +11,11 @@ Follow any of the installation methods below, then run *eilmeldung*. It will gui
 - [Via Homebrew](#via-homebrew)
 - [Via AUR (Arch)](#via-aur-arch)
 - [Via Cargo](#via-cargo)
-  - [Building on Windows](#building-on-windows)
 - [Nix Flake and Home Manager](#nix-flake-and-home-manager)
 - [Void Linux](#void-linux)
 - [Windows via Scoop](#windows-via-scoop)
+- [Windows — Install latest from GitHub](#windows--install-latest-from-github)
+- [Windows — Build from source](#windows--build-from-source)
 - [NetBSD](#netbsd)
 
 ---
@@ -71,36 +72,6 @@ To compile the latest unreleased version (`HEAD` in `main`):
 ```bash
 cargo install --locked --git https://github.com/christo-auer/eilmeldung
 ```
-
-### Building on Windows
-
-Windows requires a few extra steps because `libxml2` must be provided as a static library via [vcpkg](https://github.com/microsoft/vcpkg), and OpenSSL is compiled from source (requiring Perl).
-
-**Step 1 — Install the Rust toolchain**
-
-```pwsh
-winget install Rustlang.Rustup
-rustup default stable
-rustup target add x86_64-pc-windows-msvc
-```
-
-**Step 2 — Build**
-
-The helper script is fully self-contained — it automatically installs all remaining dependencies (Perl, LLVM, vcpkg, libxml2) via scoop if they are not already present:
-
-```pwsh
-.\scripts\build-windows.ps1
-```
-
-vcpkg is installed to `$env:LOCALAPPDATA\vcpkg` by default. Override any paths if needed:
-
-```pwsh
-.\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg" -PerlPath "C:\Strawberry\perl\bin\perl.exe" -LlvmBinPath "C:\Program Files\LLVM\bin"
-```
-
-The binary will be at `target\x86_64-pc-windows-msvc\release\eilmeldung.exe`.
-
-> **Note:** The first build downloads and compiles vcpkg dependencies and OpenSSL from source — expect 20–30 minutes. Subsequent builds are much faster.
 
 ---
 
@@ -190,19 +161,6 @@ echo "repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl
 
 ---
 
-### Installing latest main from GitHub on Windows (without cloning)
-
-Power users who want the latest unreleased code from `main` without cloning the repo can download and run `install-windows.ps1` directly:
-
-```pwsh
-irm https://raw.githubusercontent.com/christo-auer/eilmeldung/main/scripts/install-windows.ps1 -OutFile install-eilmeldung.ps1
-.\install-eilmeldung.ps1
-```
-
-This script is fully self-contained — it installs all dependencies automatically and runs `cargo install` from the GitHub repository.
-
----
-
 ## Windows via Scoop
 
 Install [scoop](https://scoop.sh/) and then
@@ -213,6 +171,53 @@ Install [scoop](https://scoop.sh/) and then
 ```
 
 Recommended terminal is [Windows Terminal](https://github.com/microsoft/terminal) with a NerdFont-patched font.
+
+---
+
+## Windows — Install latest from GitHub
+
+For power users who want the latest unreleased code from `main` without cloning the repo. Download and run `install-windows.ps1` directly:
+
+```pwsh
+irm https://raw.githubusercontent.com/christo-auer/eilmeldung/main/scripts/install-windows.ps1 -OutFile install-eilmeldung.ps1
+.\install-eilmeldung.ps1
+```
+
+This script is fully self-contained — it automatically installs all required dependencies (Perl, LLVM, vcpkg, libxml2) and runs `cargo install` from GitHub.
+
+> **Note:** The first run downloads and compiles dependencies from source — expect 20–30 minutes. Subsequent runs are much faster.
+
+---
+
+## Windows — Build from source
+
+For contributors who want to build local changes. Requires cloning the repo first.
+
+**Step 1 — Install the Rust toolchain**
+
+```pwsh
+winget install Rustlang.Rustup
+rustup default stable
+rustup target add x86_64-pc-windows-msvc
+```
+
+**Step 2 — Build**
+
+The helper script automatically installs all remaining dependencies (Perl, LLVM, vcpkg, libxml2):
+
+```pwsh
+.\scripts\build-windows.ps1
+```
+
+Override any paths if needed:
+
+```pwsh
+.\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg" -PerlPath "C:\Strawberry\perl\bin\perl.exe" -LlvmBinPath "C:\Program Files\LLVM\bin"
+```
+
+The binary will be at `target\x86_64-pc-windows-msvc\release\eilmeldung.exe`.
+
+> **Note:** The first build downloads and compiles dependencies from source — expect 20–30 minutes. Subsequent builds are much faster.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,42 +76,39 @@ cargo install --locked --git https://github.com/christo-auer/eilmeldung
 
 Windows requires a few extra steps because `libxml2` must be provided as a static library via [vcpkg](https://github.com/microsoft/vcpkg), and OpenSSL is compiled from source (requiring Perl).
 
-**Step 1 — Prerequisites (one-time setup)**
+**Step 1 — Install the Rust toolchain**
 
-Install the Rust toolchain:
 ```pwsh
 winget install Rustlang.Rustup
 rustup default stable
 rustup target add x86_64-pc-windows-msvc
 ```
 
-Install Perl (needed to compile OpenSSL). Either [Strawberry Perl](https://strawberryperl.com) or via scoop:
+**Step 2 — Install Perl**
+
+Perl is required to compile OpenSSL from source. Install via scoop or [Strawberry Perl](https://strawberryperl.com):
+
 ```pwsh
 scoop install perl
 ```
 
-Install vcpkg and the static libxml2:
-```pwsh
-git clone https://github.com/microsoft/vcpkg C:\vcpkg
-C:\vcpkg\bootstrap-vcpkg.bat
-C:\vcpkg\vcpkg install libxml2:x64-windows-static
-```
+**Step 3 — Build**
 
-**Step 2 — Build**
+The helper script handles everything else automatically (cloning vcpkg, installing libxml2, setting all required environment variables):
 
-Use the provided helper script, which sets all required environment variables automatically:
 ```pwsh
 .\scripts\build-windows.ps1
 ```
 
-If Perl or vcpkg are installed in non-default locations, pass them explicitly:
+vcpkg is installed to `$env:LOCALAPPDATA\vcpkg` by default. If Perl or vcpkg are in non-default locations, pass them explicitly:
+
 ```pwsh
-.\scripts\build-windows.ps1 -PerlPath "C:\Users\you\scoop\apps\perl\current\perl\bin\perl.exe" -VcpkgRoot "D:\vcpkg"
+.\scripts\build-windows.ps1 -PerlPath "C:\Users\you\scoop\apps\perl\current\perl\bin\perl.exe" -VcpkgRoot "D:\my-vcpkg"
 ```
 
 The binary will be at `target\x86_64-pc-windows-msvc\release\eilmeldung.exe`.
 
-> **Note:** The first build compiles OpenSSL from source and takes 20–30 minutes. Subsequent builds are much faster.
+> **Note:** The first build downloads and compiles vcpkg dependencies and OpenSSL from source — expect 20–30 minutes. Subsequent builds are much faster.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -190,15 +190,16 @@ echo "repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl
 
 ---
 
-### Installing latest main from GitHub on Windows
+### Installing latest main from GitHub on Windows (without cloning)
 
-Power users who want the latest unreleased code from `main` can use the same helper script with the `-Install` flag — it sets up all dependencies and runs `cargo install` under the hood:
+Power users who want the latest unreleased code from `main` without cloning the repo can download and run `install-windows.ps1` directly:
 
 ```pwsh
-.\scripts\build-windows.ps1 -Install
+irm https://raw.githubusercontent.com/christo-auer/eilmeldung/main/scripts/install-windows.ps1 -OutFile install-eilmeldung.ps1
+.\install-eilmeldung.ps1
 ```
 
-> **Note:** You need to clone the repo first to get the script, then run it from the repo root.
+This script is fully self-contained — it installs all dependencies automatically and runs `cargo install` from the GitHub repository.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -190,6 +190,18 @@ echo "repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl
 
 ---
 
+### Installing latest main from GitHub on Windows
+
+Power users who want the latest unreleased code from `main` can use the same helper script with the `-Install` flag — it sets up all dependencies and runs `cargo install` under the hood:
+
+```pwsh
+.\scripts\build-windows.ps1 -Install
+```
+
+> **Note:** You need to clone the repo first to get the script, then run it from the repo root.
+
+---
+
 ## Windows via Scoop
 
 Install [scoop](https://scoop.sh/) and then

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,26 +84,18 @@ rustup default stable
 rustup target add x86_64-pc-windows-msvc
 ```
 
-**Step 2 — Install Perl**
+**Step 2 — Build**
 
-Perl is required to compile OpenSSL from source. Install via scoop or [Strawberry Perl](https://strawberryperl.com):
-
-```pwsh
-scoop install perl
-```
-
-**Step 3 — Build**
-
-The helper script handles everything else automatically (cloning vcpkg, installing libxml2, setting all required environment variables):
+The helper script is fully self-contained — it automatically installs all remaining dependencies (Perl, LLVM, vcpkg, libxml2) via scoop if they are not already present:
 
 ```pwsh
 .\scripts\build-windows.ps1
 ```
 
-vcpkg is installed to `$env:LOCALAPPDATA\vcpkg` by default. If Perl or vcpkg are in non-default locations, pass them explicitly:
+vcpkg is installed to `$env:LOCALAPPDATA\vcpkg` by default. Override any paths if needed:
 
 ```pwsh
-.\scripts\build-windows.ps1 -PerlPath "C:\Users\you\scoop\apps\perl\current\perl\bin\perl.exe" -VcpkgRoot "D:\my-vcpkg"
+.\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg" -PerlPath "C:\Strawberry\perl\bin\perl.exe" -LlvmBinPath "C:\Program Files\LLVM\bin"
 ```
 
 The binary will be at `target\x86_64-pc-windows-msvc\release\eilmeldung.exe`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,7 @@ Follow any of the installation methods below, then run *eilmeldung*. It will gui
 - [Via Homebrew](#via-homebrew)
 - [Via AUR (Arch)](#via-aur-arch)
 - [Via Cargo](#via-cargo)
+  - [Building on Windows](#building-on-windows)
 - [Nix Flake and Home Manager](#nix-flake-and-home-manager)
 - [Void Linux](#void-linux)
 - [Windows via Scoop](#windows-via-scoop)
@@ -70,6 +71,47 @@ To compile the latest unreleased version (`HEAD` in `main`):
 ```bash
 cargo install --locked --git https://github.com/christo-auer/eilmeldung
 ```
+
+### Building on Windows
+
+Windows requires a few extra steps because `libxml2` must be provided as a static library via [vcpkg](https://github.com/microsoft/vcpkg), and OpenSSL is compiled from source (requiring Perl).
+
+**Step 1 — Prerequisites (one-time setup)**
+
+Install the Rust toolchain:
+```pwsh
+winget install Rustlang.Rustup
+rustup default stable
+rustup target add x86_64-pc-windows-msvc
+```
+
+Install Perl (needed to compile OpenSSL). Either [Strawberry Perl](https://strawberryperl.com) or via scoop:
+```pwsh
+scoop install perl
+```
+
+Install vcpkg and the static libxml2:
+```pwsh
+git clone https://github.com/microsoft/vcpkg C:\vcpkg
+C:\vcpkg\bootstrap-vcpkg.bat
+C:\vcpkg\vcpkg install libxml2:x64-windows-static
+```
+
+**Step 2 — Build**
+
+Use the provided helper script, which sets all required environment variables automatically:
+```pwsh
+.\scripts\build-windows.ps1
+```
+
+If Perl or vcpkg are installed in non-default locations, pass them explicitly:
+```pwsh
+.\scripts\build-windows.ps1 -PerlPath "C:\Users\you\scoop\apps\perl\current\perl\bin\perl.exe" -VcpkgRoot "D:\vcpkg"
+```
+
+The binary will be at `target\x86_64-pc-windows-msvc\release\eilmeldung.exe`.
+
+> **Note:** The first build compiles OpenSSL from source and takes 20–30 minutes. Subsequent builds are much faster.
 
 ---
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,23 +1,21 @@
 # Build eilmeldung on Windows
 #
-# Prerequisites (run once before using this script):
-#   1. Install vcpkg:
-#        git clone https://github.com/microsoft/vcpkg C:\vcpkg
-#        C:\vcpkg\bootstrap-vcpkg.bat
-#   2. Install libxml2 static:
-#        C:\vcpkg\vcpkg install libxml2:x64-windows-static
-#   3. Install Perl (required to compile OpenSSL from source).
-#      Either Strawberry Perl (https://strawberryperl.com) or via scoop:
-#        scoop install perl
+# This script is self-contained: it will automatically install vcpkg and
+# libxml2 if they are not already present.
+#
+# The only manual prerequisite is Perl, which is required to compile OpenSSL
+# from source. Install it via scoop or Strawberry Perl:
+#   scoop install perl
+#   https://strawberryperl.com
 #
 # Usage:
 #   .\scripts\build-windows.ps1
 #   .\scripts\build-windows.ps1 -PerlPath "C:\custom\perl\bin\perl.exe"
-#   .\scripts\build-windows.ps1 -VcpkgRoot "D:\vcpkg"
+#   .\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg"
 #   .\scripts\build-windows.ps1 -Debug
 
 param(
-    [string]$VcpkgRoot = "C:\vcpkg",
+    [string]$VcpkgRoot = "$env:LOCALAPPDATA\vcpkg",
     [string]$PerlPath  = "",
     [switch]$Debug
 )
@@ -29,7 +27,6 @@ $ErrorActionPreference = "Stop"
 # Resolve Perl
 # ---------------------------------------------------------------------------
 if (-not $PerlPath) {
-    # Try common locations
     $candidates = @(
         "C:\Strawberry\perl\bin\perl.exe",
         "$env:USERPROFILE\scoop\apps\perl\current\perl\bin\perl.exe",
@@ -51,44 +48,64 @@ Then re-run this script or pass -PerlPath 'C:\path\to\perl.exe'.
 }
 
 # ---------------------------------------------------------------------------
-# Verify vcpkg + libxml2
+# Bootstrap vcpkg if not present
 # ---------------------------------------------------------------------------
 $vcpkgExe = Join-Path $VcpkgRoot "vcpkg.exe"
+
 if (-not (Test-Path $vcpkgExe)) {
-    Write-Error @"
-vcpkg not found at '$VcpkgRoot'. Set it up with:
-  git clone https://github.com/microsoft/vcpkg C:\vcpkg
-  C:\vcpkg\bootstrap-vcpkg.bat
-Then re-run this script or pass -VcpkgRoot 'D:\vcpkg'.
-"@
-    exit 1
+    Write-Host "vcpkg not found at '$VcpkgRoot' -- installing..."
+
+    if (Test-Path $VcpkgRoot) {
+        # Directory exists but no vcpkg.exe -- bootstrap only
+        Write-Host "  Bootstrapping vcpkg..."
+        & "$VcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+    } else {
+        Write-Host "  Cloning vcpkg..."
+        git clone https://github.com/microsoft/vcpkg $VcpkgRoot
+        Write-Host "  Bootstrapping vcpkg..."
+        & "$VcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+    }
+
+    if (-not (Test-Path $vcpkgExe)) {
+        Write-Error "vcpkg bootstrap failed. Check the output above for errors."
+        exit 1
+    }
+    Write-Host "  vcpkg ready."
 }
 
+# ---------------------------------------------------------------------------
+# Install libxml2 static if not present
+# ---------------------------------------------------------------------------
 $libxmlLib = Join-Path $VcpkgRoot "installed\x64-windows-static\lib\xml2.lib"
+
 if (-not (Test-Path $libxmlLib)) {
-    Write-Error @"
-libxml2 static library not found. Install it with:
-  $vcpkgExe install libxml2:x64-windows-static
-"@
-    exit 1
+    Write-Host "libxml2 static not found -- installing via vcpkg (this may take several minutes)..."
+    & $vcpkgExe install libxml2:x64-windows-static
+
+    if (-not (Test-Path $libxmlLib)) {
+        Write-Error "libxml2 installation failed. Check the output above for errors."
+        exit 1
+    }
+    Write-Host "  libxml2 ready."
 }
 
 # ---------------------------------------------------------------------------
 # Set build environment
 # ---------------------------------------------------------------------------
-$env:VCPKG_ROOT             = $VcpkgRoot
-$env:VCPKGRS_DYNAMIC        = "0"
-$env:PKG_CONFIG_PATH        = "$VcpkgRoot\installed\x64-windows-static\lib\pkgconfig"
-$env:CMAKE_TOOLCHAIN_FILE   = "$VcpkgRoot\scripts\buildsystems\vcpkg.cmake"
-$env:VCPKG_TARGET_TRIPLET   = "x64-windows-static"
-$env:RUSTFLAGS              = "-C target-feature=+crt-static"
-$env:OPENSSL_SRC_PERL       = $PerlPath
+$env:VCPKG_ROOT           = $VcpkgRoot
+$env:VCPKGRS_DYNAMIC      = "0"
+$env:PKG_CONFIG_PATH      = "$VcpkgRoot\installed\x64-windows-static\lib\pkgconfig"
+$env:CMAKE_TOOLCHAIN_FILE = "$VcpkgRoot\scripts\buildsystems\vcpkg.cmake"
+$env:VCPKG_TARGET_TRIPLET = "x64-windows-static"
+$env:RUSTFLAGS            = "-C target-feature=+crt-static"
+$env:OPENSSL_SRC_PERL     = $PerlPath
 
-$profile = if ($Debug) { "debug" } else { "release" }
+$buildProfile = if ($Debug) { "debug" } else { "release" }
 $cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")
 if (-not $Debug) { $cargoArgs += "--release" }
 
-Write-Host "Building eilmeldung ($profile)..."
+Write-Host ""
+Write-Host "Building eilmeldung ($buildProfile)..."
 Write-Host "  vcpkg : $VcpkgRoot"
 Write-Host "  perl  : $PerlPath"
 Write-Host ""
@@ -97,6 +114,6 @@ cargo @cargoArgs
 
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-$binaryPath = "target\x86_64-pc-windows-msvc\$profile\eilmeldung.exe"
+$binaryPath = "target\x86_64-pc-windows-msvc\$buildProfile\eilmeldung.exe"
 Write-Host ""
 Write-Host "Build successful: $binaryPath"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -4,17 +4,19 @@
 # dependencies (Perl, LLVM, vcpkg, libxml2) if they are not already present.
 #
 # Usage:
-#   .\scripts\build-windows.ps1
+#   .\scripts\build-windows.ps1                  # build local source
+#   .\scripts\build-windows.ps1 -Install         # install latest main from GitHub
+#   .\scripts\build-windows.ps1 -Debug           # build debug binary
 #   .\scripts\build-windows.ps1 -PerlPath "C:\custom\perl\bin\perl.exe"
 #   .\scripts\build-windows.ps1 -LlvmBinPath "C:\custom\llvm\bin"
 #   .\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg"
-#   .\scripts\build-windows.ps1 -Debug
 
 param(
     [string]$VcpkgRoot   = "$env:LOCALAPPDATA\vcpkg",
     [string]$PerlPath    = "",
     [string]$LlvmBinPath = "",
-    [switch]$Debug
+    [switch]$Debug,
+    [switch]$Install
 )
 
 Set-StrictMode -Version Latest
@@ -187,19 +189,25 @@ $env:OPENSSL_SRC_PERL        = $PerlPath
 $env:LIBCLANG_PATH           = $LlvmBinPath
 $env:BINDGEN_EXTRA_CLANG_ARGS = ($bindgenIncludes | ForEach-Object { "-I`"$_`"" }) -join " "
 
-$buildProfile = if ($Debug) { "debug" } else { "release" }
-$cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")
-if (-not $Debug) { $cargoArgs += "--release" }
-
-Write-Host ""
-Write-Host "Building eilmeldung ($buildProfile)..."
 Write-Host "  vcpkg : $VcpkgRoot"
 Write-Host ""
 
-cargo @cargoArgs
+if ($Install) {
+    Write-Host "Installing eilmeldung from main branch..."
+    cargo install --locked --git https://github.com/christo-auer/eilmeldung --target x86_64-pc-windows-msvc
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Host ""
+    Write-Host "Installed successfully. Run 'eilmeldung' to start."
+} else {
+    $buildProfile = if ($Debug) { "debug" } else { "release" }
+    $cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")
+    if (-not $Debug) { $cargoArgs += "--release" }
 
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Host "Building eilmeldung ($buildProfile)..."
+    cargo @cargoArgs
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-$binaryPath = "target\x86_64-pc-windows-msvc\$buildProfile\eilmeldung.exe"
-Write-Host ""
-Write-Host "Build successful: $binaryPath"
+    $binaryPath = "target\x86_64-pc-windows-msvc\$buildProfile\eilmeldung.exe"
+    Write-Host ""
+    Write-Host "Build successful: $binaryPath"
+}

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -33,10 +33,11 @@ function Install-ViaScoop($pkg) {
 # Resolve Perl
 # ---------------------------------------------------------------------------
 if (-not $PerlPath) {
+    $perlSource = (Get-Command perl -ErrorAction SilentlyContinue)?.Source
     $candidates = @(
         "C:\Strawberry\perl\bin\perl.exe",
         "$env:USERPROFILE\scoop\apps\perl\current\perl\bin\perl.exe",
-        (Get-Command perl -ErrorAction SilentlyContinue)?.Source
+        $(if ($perlSource) { $perlSource } else { $null })
     )
     foreach ($c in $candidates) {
         if ($c -and (Test-Path $c)) { $PerlPath = $c; break }
@@ -66,10 +67,11 @@ Write-Host "  perl  : $PerlPath"
 # Resolve LLVM (required by bindgen to generate libxml2 bindings)
 # ---------------------------------------------------------------------------
 if (-not $LlvmBinPath) {
+    $clangSource = (Get-Command clang -ErrorAction SilentlyContinue)?.Source
     $candidates = @(
         "$env:USERPROFILE\scoop\apps\llvm\current\bin",
         "C:\Program Files\LLVM\bin",
-        (Split-Path (Get-Command clang -ErrorAction SilentlyContinue)?.Source)
+        $(if ($clangSource) { Split-Path $clangSource } else { $null })
     )
     foreach ($c in $candidates) {
         if ($c -and (Test-Path "$c\clang.exe")) { $LlvmBinPath = $c; break }

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -138,16 +138,54 @@ if (-not (Test-Path $libxmlLib)) {
 }
 
 # ---------------------------------------------------------------------------
+# Resolve MSVC + Windows SDK include paths for bindgen
+# ---------------------------------------------------------------------------
+$bindgenIncludes = @()
+
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (Test-Path $vswhere) {
+    $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+    if ($vsPath) {
+        $msvcVersionDir = Get-ChildItem "$vsPath\VC\Tools\MSVC" -ErrorAction SilentlyContinue |
+            Sort-Object Name | Select-Object -Last 1
+        if ($msvcVersionDir) {
+            $bindgenIncludes += "$($msvcVersionDir.FullName)\include"
+        }
+    }
+}
+
+$sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\Include"
+if (Test-Path $sdkRoot) {
+    $sdkVersion = Get-ChildItem $sdkRoot -ErrorAction SilentlyContinue |
+        Sort-Object Name | Select-Object -Last 1
+    if ($sdkVersion) {
+        $bindgenIncludes += "$($sdkVersion.FullName)\ucrt"
+        $bindgenIncludes += "$($sdkVersion.FullName)\um"
+        $bindgenIncludes += "$($sdkVersion.FullName)\shared"
+    }
+}
+
+if ($bindgenIncludes.Count -eq 0) {
+    Write-Error @"
+Could not find MSVC or Windows SDK include paths.
+Make sure Visual Studio Build Tools are installed:
+  winget install Microsoft.VisualStudio.2022.BuildTools
+"@
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
 # Set build environment
 # ---------------------------------------------------------------------------
-$env:VCPKG_ROOT           = $VcpkgRoot
-$env:VCPKGRS_DYNAMIC      = "0"
-$env:PKG_CONFIG_PATH      = "$VcpkgRoot\installed\x64-windows-static\lib\pkgconfig"
-$env:CMAKE_TOOLCHAIN_FILE = "$VcpkgRoot\scripts\buildsystems\vcpkg.cmake"
-$env:VCPKG_TARGET_TRIPLET = "x64-windows-static"
-$env:RUSTFLAGS            = "-C target-feature=+crt-static"
-$env:OPENSSL_SRC_PERL     = $PerlPath
-$env:LIBCLANG_PATH        = $LlvmBinPath
+$env:VCPKG_ROOT              = $VcpkgRoot
+$env:VCPKGRS_DYNAMIC         = "0"
+$env:PKG_CONFIG_PATH         = "$VcpkgRoot\installed\x64-windows-static\lib\pkgconfig"
+$env:CMAKE_TOOLCHAIN_FILE    = "$VcpkgRoot\scripts\buildsystems\vcpkg.cmake"
+$env:VCPKG_TARGET_TRIPLET    = "x64-windows-static"
+$env:RUSTFLAGS               = "-C target-feature=+crt-static"
+$env:OPENSSL_SRC_PERL        = $PerlPath
+$env:LIBCLANG_PATH           = $LlvmBinPath
+$env:BINDGEN_EXTRA_CLANG_ARGS = ($bindgenIncludes | ForEach-Object { "-I`"$_`"" }) -join " "
 
 $buildProfile = if ($Debug) { "debug" } else { "release" }
 $cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -91,7 +91,7 @@ if (-not (Test-Path $vcpkgExe)) {
 # ---------------------------------------------------------------------------
 # Install libxml2 static if not present
 # ---------------------------------------------------------------------------
-$libxmlLib = Join-Path $VcpkgRoot "installed\x64-windows-static\lib\xml2.lib"
+$libxmlLib = Join-Path $VcpkgRoot "installed\x64-windows-static\lib\libxml2.lib"
 
 if (-not (Test-Path $libxmlLib)) {
     Write-Host "libxml2 static not found -- installing via vcpkg (this may take several minutes)..."

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,27 +1,33 @@
 # Build eilmeldung on Windows
 #
-# This script is self-contained: it will automatically install vcpkg and
-# libxml2 if they are not already present.
-#
-# The only manual prerequisite is Perl, which is required to compile OpenSSL
-# from source. Install it via scoop or Strawberry Perl:
-#   scoop install perl
-#   https://strawberryperl.com
+# This script is self-contained: it will automatically install all required
+# dependencies (Perl, LLVM, vcpkg, libxml2) if they are not already present.
 #
 # Usage:
 #   .\scripts\build-windows.ps1
 #   .\scripts\build-windows.ps1 -PerlPath "C:\custom\perl\bin\perl.exe"
+#   .\scripts\build-windows.ps1 -LlvmBinPath "C:\custom\llvm\bin"
 #   .\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg"
 #   .\scripts\build-windows.ps1 -Debug
 
 param(
-    [string]$VcpkgRoot = "$env:LOCALAPPDATA\vcpkg",
-    [string]$PerlPath  = "",
+    [string]$VcpkgRoot   = "$env:LOCALAPPDATA\vcpkg",
+    [string]$PerlPath    = "",
+    [string]$LlvmBinPath = "",
     [switch]$Debug
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+function Install-ViaScoop($pkg) {
+    if (Get-Command scoop -ErrorAction SilentlyContinue) {
+        Write-Host "$pkg not found -- installing via scoop..."
+        scoop install $pkg
+        return $true
+    }
+    return $false
+}
 
 # ---------------------------------------------------------------------------
 # Resolve Perl
@@ -38,16 +44,9 @@ if (-not $PerlPath) {
 }
 
 if (-not $PerlPath -or -not (Test-Path $PerlPath)) {
-    # Try to install via scoop if available
-    if (Get-Command scoop -ErrorAction SilentlyContinue) {
-        Write-Host "Perl not found -- installing via scoop..."
-        scoop install perl
-        # Re-detect via PATH after install
+    if (Install-ViaScoop "perl") {
         $found = Get-Command perl -ErrorAction SilentlyContinue
-        if ($found) {
-            $PerlPath = $found.Source
-            Write-Host "  Perl ready at $PerlPath"
-        }
+        if ($found) { $PerlPath = $found.Source }
     }
 }
 
@@ -61,6 +60,39 @@ Then re-run this script or pass -PerlPath 'C:\path\to\perl.exe'.
 "@
     exit 1
 }
+Write-Host "  perl  : $PerlPath"
+
+# ---------------------------------------------------------------------------
+# Resolve LLVM (required by bindgen to generate libxml2 bindings)
+# ---------------------------------------------------------------------------
+if (-not $LlvmBinPath) {
+    $candidates = @(
+        "$env:USERPROFILE\scoop\apps\llvm\current\bin",
+        "C:\Program Files\LLVM\bin",
+        (Split-Path (Get-Command clang -ErrorAction SilentlyContinue)?.Source)
+    )
+    foreach ($c in $candidates) {
+        if ($c -and (Test-Path "$c\clang.exe")) { $LlvmBinPath = $c; break }
+    }
+}
+
+if (-not $LlvmBinPath -or -not (Test-Path "$LlvmBinPath\clang.exe")) {
+    if (Install-ViaScoop "llvm") {
+        $found = Get-Command clang -ErrorAction SilentlyContinue
+        if ($found) { $LlvmBinPath = Split-Path $found.Source }
+    }
+}
+
+if (-not $LlvmBinPath -or -not (Test-Path "$LlvmBinPath\clang.exe")) {
+    Write-Error @"
+LLVM/clang not found and could not be installed automatically.
+Install it manually via:
+  scoop install llvm
+Then re-run this script or pass -LlvmBinPath 'C:\path\to\llvm\bin'.
+"@
+    exit 1
+}
+Write-Host "  llvm  : $LlvmBinPath"
 
 # ---------------------------------------------------------------------------
 # Bootstrap vcpkg if not present
@@ -71,7 +103,6 @@ if (-not (Test-Path $vcpkgExe)) {
     Write-Host "vcpkg not found at '$VcpkgRoot' -- installing..."
 
     if (Test-Path $VcpkgRoot) {
-        # Directory exists but no vcpkg.exe -- bootstrap only
         Write-Host "  Bootstrapping vcpkg..."
         & "$VcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
     } else {
@@ -114,6 +145,7 @@ $env:CMAKE_TOOLCHAIN_FILE = "$VcpkgRoot\scripts\buildsystems\vcpkg.cmake"
 $env:VCPKG_TARGET_TRIPLET = "x64-windows-static"
 $env:RUSTFLAGS            = "-C target-feature=+crt-static"
 $env:OPENSSL_SRC_PERL     = $PerlPath
+$env:LIBCLANG_PATH        = $LlvmBinPath
 
 $buildProfile = if ($Debug) { "debug" } else { "release" }
 $cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")
@@ -122,7 +154,6 @@ if (-not $Debug) { $cargoArgs += "--release" }
 Write-Host ""
 Write-Host "Building eilmeldung ($buildProfile)..."
 Write-Host "  vcpkg : $VcpkgRoot"
-Write-Host "  perl  : $PerlPath"
 Write-Host ""
 
 cargo @cargoArgs

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,102 @@
+# Build eilmeldung on Windows
+#
+# Prerequisites (run once before using this script):
+#   1. Install vcpkg:
+#        git clone https://github.com/microsoft/vcpkg C:\vcpkg
+#        C:\vcpkg\bootstrap-vcpkg.bat
+#   2. Install libxml2 static:
+#        C:\vcpkg\vcpkg install libxml2:x64-windows-static
+#   3. Install Perl (required to compile OpenSSL from source).
+#      Either Strawberry Perl (https://strawberryperl.com) or via scoop:
+#        scoop install perl
+#
+# Usage:
+#   .\scripts\build-windows.ps1
+#   .\scripts\build-windows.ps1 -PerlPath "C:\custom\perl\bin\perl.exe"
+#   .\scripts\build-windows.ps1 -VcpkgRoot "D:\vcpkg"
+#   .\scripts\build-windows.ps1 -Debug
+
+param(
+    [string]$VcpkgRoot = "C:\vcpkg",
+    [string]$PerlPath  = "",
+    [switch]$Debug
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ---------------------------------------------------------------------------
+# Resolve Perl
+# ---------------------------------------------------------------------------
+if (-not $PerlPath) {
+    # Try common locations
+    $candidates = @(
+        "C:\Strawberry\perl\bin\perl.exe",
+        "$env:USERPROFILE\scoop\apps\perl\current\perl\bin\perl.exe",
+        (Get-Command perl -ErrorAction SilentlyContinue)?.Source
+    )
+    foreach ($c in $candidates) {
+        if ($c -and (Test-Path $c)) { $PerlPath = $c; break }
+    }
+}
+
+if (-not $PerlPath -or -not (Test-Path $PerlPath)) {
+    Write-Error @"
+Perl not found. Install it via:
+  scoop install perl
+or download Strawberry Perl from https://strawberryperl.com
+Then re-run this script or pass -PerlPath 'C:\path\to\perl.exe'.
+"@
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Verify vcpkg + libxml2
+# ---------------------------------------------------------------------------
+$vcpkgExe = Join-Path $VcpkgRoot "vcpkg.exe"
+if (-not (Test-Path $vcpkgExe)) {
+    Write-Error @"
+vcpkg not found at '$VcpkgRoot'. Set it up with:
+  git clone https://github.com/microsoft/vcpkg C:\vcpkg
+  C:\vcpkg\bootstrap-vcpkg.bat
+Then re-run this script or pass -VcpkgRoot 'D:\vcpkg'.
+"@
+    exit 1
+}
+
+$libxmlLib = Join-Path $VcpkgRoot "installed\x64-windows-static\lib\xml2.lib"
+if (-not (Test-Path $libxmlLib)) {
+    Write-Error @"
+libxml2 static library not found. Install it with:
+  $vcpkgExe install libxml2:x64-windows-static
+"@
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Set build environment
+# ---------------------------------------------------------------------------
+$env:VCPKG_ROOT             = $VcpkgRoot
+$env:VCPKGRS_DYNAMIC        = "0"
+$env:PKG_CONFIG_PATH        = "$VcpkgRoot\installed\x64-windows-static\lib\pkgconfig"
+$env:CMAKE_TOOLCHAIN_FILE   = "$VcpkgRoot\scripts\buildsystems\vcpkg.cmake"
+$env:VCPKG_TARGET_TRIPLET   = "x64-windows-static"
+$env:RUSTFLAGS              = "-C target-feature=+crt-static"
+$env:OPENSSL_SRC_PERL       = $PerlPath
+
+$profile = if ($Debug) { "debug" } else { "release" }
+$cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")
+if (-not $Debug) { $cargoArgs += "--release" }
+
+Write-Host "Building eilmeldung ($profile)..."
+Write-Host "  vcpkg : $VcpkgRoot"
+Write-Host "  perl  : $PerlPath"
+Write-Host ""
+
+cargo @cargoArgs
+
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$binaryPath = "target\x86_64-pc-windows-msvc\$profile\eilmeldung.exe"
+Write-Host ""
+Write-Host "Build successful: $binaryPath"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -42,11 +42,11 @@ if (-not $PerlPath -or -not (Test-Path $PerlPath)) {
     if (Get-Command scoop -ErrorAction SilentlyContinue) {
         Write-Host "Perl not found -- installing via scoop..."
         scoop install perl
-        # Re-detect after install
-        $scoopPerl = "$env:USERPROFILE\scoop\apps\perl\current\perl\bin\perl.exe"
-        if (Test-Path $scoopPerl) {
-            $PerlPath = $scoopPerl
-            Write-Host "  Perl ready."
+        # Re-detect via PATH after install
+        $found = Get-Command perl -ErrorAction SilentlyContinue
+        if ($found) {
+            $PerlPath = $found.Source
+            Write-Host "  Perl ready at $PerlPath"
         }
     }
 }

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -38,8 +38,23 @@ if (-not $PerlPath) {
 }
 
 if (-not $PerlPath -or -not (Test-Path $PerlPath)) {
+    # Try to install via scoop if available
+    if (Get-Command scoop -ErrorAction SilentlyContinue) {
+        Write-Host "Perl not found -- installing via scoop..."
+        scoop install perl
+        # Re-detect after install
+        $scoopPerl = "$env:USERPROFILE\scoop\apps\perl\current\perl\bin\perl.exe"
+        if (Test-Path $scoopPerl) {
+            $PerlPath = $scoopPerl
+            Write-Host "  Perl ready."
+        }
+    }
+}
+
+if (-not $PerlPath -or -not (Test-Path $PerlPath)) {
     Write-Error @"
-Perl not found. Install it via:
+Perl not found and could not be installed automatically.
+Install it manually via:
   scoop install perl
 or download Strawberry Perl from https://strawberryperl.com
 Then re-run this script or pass -PerlPath 'C:\path\to\perl.exe'.

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,24 +1,24 @@
-# Build eilmeldung on Windows from a local clone.
+# Install eilmeldung on Windows from the latest main branch on GitHub.
 #
-# For contributors and developers who want to build local changes.
-# For installing the latest code from GitHub without cloning, use
-# scripts/install-windows.ps1 instead.
+# For end users and power users who want the latest unreleased code.
+# Does not require cloning the repository. Run directly:
+#
+#   irm https://raw.githubusercontent.com/christo-auer/eilmeldung/main/scripts/install-windows.ps1 -OutFile install-eilmeldung.ps1
+#   .\install-eilmeldung.ps1
 #
 # All required dependencies (Perl, LLVM, vcpkg, libxml2) are installed
 # automatically if not already present.
 #
 # Usage:
-#   .\scripts\build-windows.ps1
-#   .\scripts\build-windows.ps1 -Debug
-#   .\scripts\build-windows.ps1 -PerlPath "C:\custom\perl\bin\perl.exe"
-#   .\scripts\build-windows.ps1 -LlvmBinPath "C:\custom\llvm\bin"
-#   .\scripts\build-windows.ps1 -VcpkgRoot "D:\my-vcpkg"
+#   .\install-windows.ps1
+#   .\install-windows.ps1 -PerlPath "C:\custom\perl\bin\perl.exe"
+#   .\install-windows.ps1 -LlvmBinPath "C:\custom\llvm\bin"
+#   .\install-windows.ps1 -VcpkgRoot "D:\my-vcpkg"
 
 param(
     [string]$VcpkgRoot   = "$env:LOCALAPPDATA\vcpkg",
     [string]$PerlPath    = "",
-    [string]$LlvmBinPath = "",
-    [switch]$Debug
+    [string]$LlvmBinPath = ""
 )
 
 Set-StrictMode -Version Latest
@@ -174,7 +174,7 @@ Make sure Visual Studio Build Tools are installed:
 }
 
 # ---------------------------------------------------------------------------
-# Set build environment and build
+# Set build environment and install
 # ---------------------------------------------------------------------------
 $env:VCPKG_ROOT               = $VcpkgRoot
 $env:VCPKGRS_DYNAMIC          = "0"
@@ -186,16 +186,13 @@ $env:OPENSSL_SRC_PERL         = $PerlPath
 $env:LIBCLANG_PATH            = $LlvmBinPath
 $env:BINDGEN_EXTRA_CLANG_ARGS = ($bindgenIncludes | ForEach-Object { "-I`"$_`"" }) -join " "
 
-$buildProfile = if ($Debug) { "debug" } else { "release" }
-$cargoArgs = @("build", "--target", "x86_64-pc-windows-msvc")
-if (-not $Debug) { $cargoArgs += "--release" }
-
 Write-Host "  vcpkg : $VcpkgRoot"
 Write-Host ""
-Write-Host "Building eilmeldung ($buildProfile)..."
-cargo @cargoArgs
+Write-Host "Installing eilmeldung from latest main..."
+
+cargo install --locked --git https://github.com/christo-auer/eilmeldung --target x86_64-pc-windows-msvc
+
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-$binaryPath = "target\x86_64-pc-windows-msvc\$buildProfile\eilmeldung.exe"
 Write-Host ""
-Write-Host "Build successful: $binaryPath"
+Write-Host "Installed successfully. Run 'eilmeldung' to start."


### PR DESCRIPTION
Closes #249

Please indicate if and how you've used LLMs to create the changes:
- [ ] no LLMs were used
- [ ] just auto-complete
- [X] AI-assisted: I guided AI to create a script and gave it the applications and env variables it needs to use. I ran the script multiple times and fixed its bugs.
- [X] fully LLM-generated (generating of the PR and Issue and their content)


## Summary

Building eilmeldung from source on Windows requires a specific set of native dependencies and environment variables that are not documented anywhere. This PR adds tooling and documentation to make Windows cargo builds accessible to both contributors and power users.

## Why this is needed

The CI (`build_windows` job in `build-main.yml`) builds successfully on Windows by:
- Installing `libxml2:x64-windows-static` via **vcpkg**
- Setting 6+ environment variables (`VCPKG_ROOT`, `PKG_CONFIG_PATH`, `LIBCLANG_PATH`, `BINDGEN_EXTRA_CLANG_ARGS`, `RUSTFLAGS`, `OPENSSL_SRC_PERL`, etc.)
- Using **LLVM/clang** with explicit MSVC + Windows SDK include paths so **bindgen** can generate libxml2 bindings

None of this was documented for local builds. A Windows user following the existing "Via Cargo" instructions would hit cryptic build failures (`stdio.h file not found`, `libxml2 not found`, etc.) with no guidance.

## What this PR adds

### `scripts/build-windows.ps1` — for contributors
- Targets developers who have cloned the repo and want to build local changes
- Automatically installs missing dependencies (Perl, LLVM, vcpkg, libxml2) via scoop
- Detects MSVC + Windows SDK include paths via `vswhere` and sets `BINDGEN_EXTRA_CLANG_ARGS`
- Sets all required environment variables before running `cargo build --release`
- Idempotent: skips steps that are already done on subsequent runs

### `scripts/install-windows.ps1` — for power users
- Targets users who want the latest `main` without cloning the repository
- Fully standalone — downloadable and runnable via `irm`:
  ```pwsh
  irm https://raw.githubusercontent.com/christo-auer/eilmeldung/main/scripts/install-windows.ps1 -OutFile install-eilmeldung.ps1
  .\install-eilmeldung.ps1
  ```
- Same dependency setup as `build-windows.ps1`, but runs `cargo install --git` instead

### `docs/installation.md`
- Adds three clearly separated Windows sections in order of complexity:
  1. **Windows via Scoop** (existing, moved up) — easiest, for most users
  2. **Windows — Install latest from GitHub** (new) — power users, no clone needed
  3. **Windows — Build from source** (new) — contributors with a local clone