### PR TITLE
fix: expand %VAR% env vars in cmd: secrets and support cmd: for url/user on Windows

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -611,8 +611,8 @@ Upon first starting `eilmeldung`, the user is asked to enter login information a
 | ---                   | ---    | ---                                        | ---                                                                           |
 | `login_type`          | string |                                            | Type of login: `"no_login"`, `"direct_password"`, `"direct_token"`, `"oauth"` |
 | `provider`            | string | all                                        | Provider: `"local_rss"`, `"freshrss"`, etc.                                   |
-| `url`                 | string | `oauth` (required); `direct_password`, `direct_token` (optional) | URL for connection |
-| `user`                | string | `direct_password`                          | Username for direct login                                                     |
+| `url`                 | secret | `oauth` (required); `direct_password`, `direct_token` (optional) | URL for connection |
+| `user`                | secret | `direct_password`                          | Username for direct login                                                     |
 | `password`            | secret | `direct_password`                          | Password or command which produces password  (see below!)                     |
 | `token`               | secret | `direct_token`                             | Token for login by token                                                      |
 | `oauth_client_id`     | string | `oauth`                                    | *Optional*: client ID for oauth login (see note below)                        |
@@ -630,6 +630,20 @@ Configuration options with type *secret* are strings which
 
 - either contain the secret itself (e.g, `password = "abcd1234" `); storing password in *clear text* is **NOT RECOMMENDED**
 - or contain a command with prefix `cmd:` which outputs the secret to stdout (e.g., `password = "cmd:pass my-passwords/eilmeldung"`); **THIS IS THE WAY**
+
+Note that `url` and `user` also support the `cmd:` prefix, so you can retrieve all credentials from a password manager — not just the password.
+
+#### Windows: Environment Variable Expansion in `cmd:` Secrets
+
+On Windows, `%VAR%` style environment variables are expanded before the command is executed. This lets you reference your home directory portably:
+
+```toml
+password = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-pass.ps1"
+url      = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-url.ps1"
+user     = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-user.ps1"
+```
+
+Note that `.ps1` scripts cannot be run directly on Windows — they must be invoked via `pwsh -NoProfile -File`.
 
 For step-by-step examples of setting up secrets for FreshRSS, see:
 - [FreshRSS automatic login with pass (Linux and macOS)](examples/freshrss_secrets_linux_macos.md)

--- a/docs/examples/freshrss_secrets_windows.md
+++ b/docs/examples/freshrss_secrets_windows.md
@@ -4,63 +4,92 @@ This guide shows how to securely store your FreshRSS credentials using GPG on Wi
 
 ## Install and Setup GPG
 
-```powershell
-# Install gpg but don't run it yet (we need to create the env var first)
-scoop install gpg4win
+Install gpg4win via scoop:
 
+```powershell
+scoop install gpg4win
+```
+
+> **Important:** If you have `git` installed via scoop, it ships its own MinGW-based `gpg` that shadows gpg4win and cannot handle Windows-style paths. Override the shims to use gpg4win's native Windows binary:
+>
+> ```powershell
+> scoop shim add gpg "$env:USERPROFILE\scoop\apps\gpg4win\current\GnuPG\bin\gpg.exe"
+> scoop shim add gpg-agent "$env:USERPROFILE\scoop\apps\gpg4win\current\GnuPG\bin\gpg-agent.exe"
+> scoop shim add gpgconf "$env:USERPROFILE\scoop\apps\gpg4win\current\GnuPG\bin\gpgconf.exe"
+> scoop shim add gpg-connect-agent "$env:USERPROFILE\scoop\apps\gpg4win\current\GnuPG\bin\gpg-connect-agent.exe"
+> ```
+>
+> Verify the correct binary is active:
+> ```powershell
+> gpg --version  # should mention GnuPG from gpg4win, not Git bundled gpg
+> ```
+
+Set up the GnuPG home directory and generate a key:
+
+```powershell
 # Create the GnuPG config directory
 mkdir "$env:USERPROFILE\.config\gnupg" -Force
 
 # Set permissions
 icacls "$env:USERPROFILE\.config\gnupg" /inheritance:r /grant:r "$env:USERNAME`:F"
 
-# Set the GNUPGHOME env var permanently
+# Set GNUPGHOME permanently (gpg4win understands Windows paths)
 [Environment]::SetEnvironmentVariable("GNUPGHOME", "$env:USERPROFILE\.config\gnupg", "User")
 
 # Restart your terminal, then generate a key
-~\scoop\apps\gpg4win\current\GnuPG\bin\gpg.exe --gen-key
+gpg --gen-key
 ```
 
 ## Encrypt Your FreshRSS URL, Username, and Password
 
 ```powershell
-mkdir ~/.passwords
+mkdir "$env:USERPROFILE\.passwords" -Force
 "https://your_freshrss_domain.com" | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-url.gpg"
-"your_freshrss_username" | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"
-"your_api_password" | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"
+"your_freshrss_username"           | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"
+"your_api_password"                | gpg --encrypt --recipient "your_email_address" --output "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"
 ```
 
 ### Test Decryption
 
 ```powershell
-gpg --quiet --decrypt ~/.passwords/eilmeldung-url.gpg
-gpg --quiet --decrypt ~/.passwords/eilmeldung-user.gpg
-gpg --quiet --decrypt ~/.passwords/eilmeldung-pass.gpg
+gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-url.gpg"
+gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"
+gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"
 ```
+
+Each command should print the decrypted value with no errors.
 
 ## Create the Retrieval Scripts
 
 ```powershell
-New-Item "$env:USERPROFILE\.config\eilmeldung\get-url.ps1" -Force
-New-Item "$env:USERPROFILE\.config\eilmeldung\get-user.ps1" -Force
-New-Item "$env:USERPROFILE\.config\eilmeldung\get-pass.ps1" -Force
+New-Item "$env:USERPROFILE\.config\eilmeldung" -ItemType Directory -Force
+
+Set-Content "$env:USERPROFILE\.config\eilmeldung\get-url.ps1"  'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-url.gpg"'
+Set-Content "$env:USERPROFILE\.config\eilmeldung\get-user.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"'
+Set-Content "$env:USERPROFILE\.config\eilmeldung\get-pass.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"'
 ```
 
-Add content to each:
+### Test the Scripts
 
 ```powershell
-Add-Content "$env:USERPROFILE\.config\eilmeldung\get-url.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-url.gpg"'
-Add-Content "$env:USERPROFILE\.config\eilmeldung\get-user.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-user.gpg"'
-Add-Content "$env:USERPROFILE\.config\eilmeldung\get-pass.ps1" 'gpg --quiet --decrypt "$env:USERPROFILE\.passwords\eilmeldung-pass.gpg"'
+pwsh -NoProfile -File "$env:USERPROFILE\.config\eilmeldung\get-url.ps1"
+pwsh -NoProfile -File "$env:USERPROFILE\.config\eilmeldung\get-user.ps1"
+pwsh -NoProfile -File "$env:USERPROFILE\.config\eilmeldung\get-pass.ps1"
 ```
 
+Each script should print the decrypted value.
+
 ## eilmeldung Config for FreshRSS
+
+The `url`, `user`, and `password` fields all support the `cmd:` prefix on Windows.
+Use `pwsh -NoProfile -File` to invoke your `.ps1` scripts, and `%USERPROFILE%` to
+reference your home directory (expanded automatically by eilmeldung):
 
 ```toml
 [login_setup]
 login_type = "direct_password"
 provider = "freshrss"
-url = "cmd:%USERPROFILE%/.config/eilmeldung/get-url.ps1"
-user = "cmd:%USERPROFILE%/.config/eilmeldung/get-user.ps1"
-password = "cmd:%USERPROFILE%/.config/eilmeldung/get-pass.ps1"
+url      = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-url.ps1"
+user     = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-user.ps1"
+password = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-pass.ps1"
 ```

--- a/src/config/login_configuration.rs
+++ b/src/config/login_configuration.rs
@@ -71,7 +71,10 @@ fn expand_env_vars(s: &str) -> String {
                 }
                 if closed && !var_name.is_empty() {
                     if let Ok(val) = env::var(&var_name) {
-                        result.push_str(&val);
+                        // Normalize backslashes to forward slashes so that
+                        // shell_words::split (a POSIX parser) does not treat
+                        // them as escape characters.
+                        result.push_str(&val.replace('\\', "/"));
                     } else {
                         // Leave unexpanded if the variable isn't set
                         result.push('%');
@@ -443,6 +446,62 @@ mod test {
     #[case("cmd:/home/user/pass.sh\'")]
     fn test_secret_parsing_command_fail(#[case] s: &str) {
         assert_matches!(Secret::from_str(s), Err(ConfigError::SecretParseError));
+    }
+
+    #[cfg(target_os = "windows")]
+    mod expand_env_vars_tests {
+        use super::super::expand_env_vars;
+
+        #[test]
+        fn expands_known_variable() {
+            std::env::set_var("EILMELDUNG_TEST_VAR", r"C:\Users\test");
+            let result = expand_env_vars("prefix/%EILMELDUNG_TEST_VAR%/suffix");
+            // backslashes in expanded value must be normalized to forward slashes
+            assert_eq!(result, "prefix/C:/Users/test/suffix");
+            std::env::remove_var("EILMELDUNG_TEST_VAR");
+        }
+
+        #[test]
+        fn leaves_unknown_variable_intact() {
+            std::env::remove_var("EILMELDUNG_UNDEFINED_VAR");
+            let result = expand_env_vars("%EILMELDUNG_UNDEFINED_VAR%");
+            assert_eq!(result, "%EILMELDUNG_UNDEFINED_VAR%");
+        }
+
+        #[test]
+        fn unmatched_percent_passed_through() {
+            let result = expand_env_vars("100% done");
+            assert_eq!(result, "100% done");
+        }
+
+        #[test]
+        fn no_variables_unchanged() {
+            let result = expand_env_vars("pwsh -NoProfile -File /some/script.ps1");
+            assert_eq!(result, "pwsh -NoProfile -File /some/script.ps1");
+        }
+
+        #[test]
+        fn cmd_secret_expands_and_splits_correctly() {
+            use super::super::Secret;
+            use std::str::FromStr;
+            std::env::set_var("EILMELDUNG_TEST_HOME", r"C:\Users\test");
+            let Secret::Command(args) = Secret::from_str(
+                r"cmd:pwsh -NoProfile -File %EILMELDUNG_TEST_HOME%/.config/get-pass.ps1",
+            )
+            .expect("should parse") else {
+                panic!("expected Command variant");
+            };
+            assert_eq!(
+                args,
+                vec![
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    "C:/Users/test/.config/get-pass.ps1"
+                ]
+            );
+            std::env::remove_var("EILMELDUNG_TEST_HOME");
+        }
     }
 
     #[test]

--- a/src/config/login_configuration.rs
+++ b/src/config/login_configuration.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     process::{Command, Stdio},
     str::FromStr,
 };
@@ -70,7 +69,7 @@ fn expand_env_vars(s: &str) -> String {
                     var_name.push(inner);
                 }
                 if closed && !var_name.is_empty() {
-                    if let Ok(val) = env::var(&var_name) {
+                    if let Ok(val) = std::env::var(&var_name) {
                         // Normalize backslashes to forward slashes so that
                         // shell_words::split (a POSIX parser) does not treat
                         // them as escape characters.

--- a/src/config/login_configuration.rs
+++ b/src/config/login_configuration.rs
@@ -15,9 +15,9 @@ pub struct LoginConfiguration {
     pub login_type: LoginType,
     pub provider: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<String>,
+    pub user: Option<Secret>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<Secret>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<Secret>,
@@ -222,12 +222,16 @@ impl LoginConfiguration {
             Secret::get_secret_option(self.password.as_ref())?.as_ref(),
             "password needed",
         )?;
+        let user = unwrap_or_config_error(
+            Secret::get_secret_option(self.user.as_ref())?.as_ref(),
+            "user name needed",
+        )?;
 
         Ok(LoginData::Direct(DirectLogin::Password(
             news_flash::models::PasswordLogin {
                 id: PluginID::new(&self.provider),
-                url: self.url.to_owned(),
-                user: unwrap_or_config_error(self.user.as_ref(), "user name needed")?,
+                url: Secret::get_secret_option(self.url.as_ref())?,
+                user,
                 password,
                 basic_auth: self.to_basic_auth()?,
             },
@@ -243,7 +247,7 @@ impl LoginConfiguration {
         Ok(LoginData::Direct(DirectLogin::Token(
             news_flash::models::TokenLogin {
                 id: PluginID::new(&self.provider),
-                url: self.url.to_owned(),
+                url: Secret::get_secret_option(self.url.as_ref())?,
                 token,
                 basic_auth: self.to_basic_auth()?,
             },
@@ -269,9 +273,14 @@ impl LoginConfiguration {
             }
         };
 
+        let url = unwrap_or_config_error(
+            Secret::get_secret_option(self.url.as_ref())?.as_ref(),
+            "url needed",
+        )?;
+
         Ok(LoginData::OAuth(OAuthData {
             id: PluginID::new(&self.provider),
-            url: unwrap_or_config_error(self.url.as_ref(), "url needed")?,
+            url,
             custom_api_secret: api_secret,
         }))
     }
@@ -297,8 +306,11 @@ impl LoginConfiguration {
         Self {
             login_type: LoginType::DirectPassword,
             provider: direct_login.id.as_str().to_owned(),
-            url: direct_login.url.to_owned(),
-            user: Some(direct_login.user.to_owned()),
+            url: direct_login
+                .url
+                .as_deref()
+                .map(|u| Secret::Verbatim(u.to_owned())),
+            user: Some(Secret::Verbatim(direct_login.user.to_owned())),
             password: Some(Secret::Verbatim(direct_login.password.to_owned())),
             ..Default::default()
         }
@@ -321,7 +333,10 @@ impl LoginConfiguration {
         Self {
             login_type: LoginType::DirectToken,
             provider: token_login.id.as_str().to_owned(),
-            url: token_login.url.to_owned(),
+            url: token_login
+                .url
+                .as_deref()
+                .map(|u| Secret::Verbatim(u.to_owned())),
             token: Some(Secret::Verbatim(token_login.token.to_owned())),
             ..Self::default()
         }
@@ -332,7 +347,7 @@ impl LoginConfiguration {
         Self {
             login_type: LoginType::OAuth,
             provider: oauth_data.id.as_str().to_owned(),
-            url: Some(oauth_data.url.to_owned()),
+            url: Some(Secret::Verbatim(oauth_data.url.to_owned())),
             oauth_client_id: oauth_data
                 .custom_api_secret
                 .as_ref()
@@ -352,6 +367,8 @@ impl LoginConfiguration {
 
     fn redact_secrets(self) -> Self {
         Self {
+            url: Self::redact(self.url),
+            user: Self::redact(self.user),
             password: Self::redact(self.password),
             oauth_client_secret: Self::redact(self.oauth_client_secret),
             basic_auth_password: Self::redact(self.basic_auth_password),
@@ -559,8 +576,8 @@ mod test {
         let login_configuration = LoginConfiguration {
             login_type: LoginType::DirectPassword,
             provider: "abc".to_owned(),
-            user: Some("username".to_owned()),
-            url: Some("http://www.rssprovider.com/".to_owned()),
+            user: Some(Secret::Verbatim("username".to_owned())),
+            url: Some(Secret::Verbatim("http://www.rssprovider.com/".to_owned())),
             password: Some(Secret::from_str("cmd:echo \"secret\"").unwrap()),
             token: None,
 
@@ -597,7 +614,7 @@ mod test {
             login_type: LoginType::OAuth,
             provider: "abc".to_owned(),
             user: None,
-            url: Some("http://www.rssprovider.com/".to_owned()),
+            url: Some(Secret::Verbatim("http://www.rssprovider.com/".to_owned())),
             password: None,
             token: None,
 
@@ -647,10 +664,12 @@ mod test {
         let login_configuration = LoginConfiguration {
             login_type,
             provider: "abc".to_owned(),
-            user: user.unwrap_or(Some("username")).map(str::to_owned),
+            user: user
+                .unwrap_or(Some("username"))
+                .map(|s| Secret::Verbatim(s.to_owned())),
             url: url
                 .unwrap_or(Some("http://www.rssprovider.com/"))
-                .map(str::to_owned),
+                .map(|s| Secret::Verbatim(s.to_owned())),
             password: password
                 .unwrap_or(Some("cmd:echo \"secret1\""))
                 .map(|cmd| Secret::from_str(cmd).unwrap()),

--- a/src/config/login_configuration.rs
+++ b/src/config/login_configuration.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     process::{Command, Stdio},
     str::FromStr,
 };
@@ -50,6 +51,50 @@ pub enum Secret {
     Command(Vec<String>),
 }
 
+/// Expands `%VAR%` style environment variables on Windows.
+/// On non-Windows platforms the string is returned unchanged.
+fn expand_env_vars(s: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        let mut result = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '%' {
+                let mut var_name = String::new();
+                let mut closed = false;
+                for inner in chars.by_ref() {
+                    if inner == '%' {
+                        closed = true;
+                        break;
+                    }
+                    var_name.push(inner);
+                }
+                if closed && !var_name.is_empty() {
+                    if let Ok(val) = env::var(&var_name) {
+                        result.push_str(&val);
+                    } else {
+                        // Leave unexpanded if the variable isn't set
+                        result.push('%');
+                        result.push_str(&var_name);
+                        result.push('%');
+                    }
+                } else {
+                    // Unmatched '%' — pass through literally
+                    result.push('%');
+                    result.push_str(&var_name);
+                }
+            } else {
+                result.push(c);
+            }
+        }
+        result
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        s.to_owned()
+    }
+}
+
 impl FromStr for Secret {
     type Err = ConfigError;
 
@@ -59,7 +104,10 @@ impl FromStr for Secret {
                 .trim()
                 .split_once(":")
                 .ok_or(ConfigError::SecretParseError)?;
-            Secret::Command(shell_words::split(command).map_err(|_| ConfigError::SecretParseError)?)
+            let command = expand_env_vars(command);
+            Secret::Command(
+                shell_words::split(&command).map_err(|_| ConfigError::SecretParseError)?,
+            )
         } else {
             Secret::Verbatim(s.to_owned())
         })


### PR DESCRIPTION
Closes #251

## Summary

This PR fixes two issues that prevent Windows users from using `cmd:` secrets effectively in `login_setup`.

## Changes

### 1. `%VAR%` expansion in `cmd:` secrets (`src/config/login_configuration.rs`)

Added `expand_env_vars()` — a Windows-only function that expands `%VAR%` style environment variables in `cmd:` secret strings before they are parsed by `shell_words::split`. Backslashes in expanded values are normalized to forward slashes to prevent them being treated as escape characters by the POSIX shell word parser.

```toml
# This now works on Windows:
password = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-pass.ps1"
```

Unit tests are included covering: normal expansion, backslash normalization, undefined variables (left intact), unmatched `%`, and end-to-end `Secret::from_str` parsing.

### 2. `url` and `user` fields changed to `Option<Secret>`

`url` and `user` in `LoginConfiguration` were `Option<String>`, so the `cmd:` prefix was never executed — the literal string was sent to the API. Changed both to `Option<Secret>` so they support the same verbatim and `cmd:` syntax as `password`, `token`, and other secret fields.

```toml
# These now work:
url  = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-url.ps1"
user = "cmd:pwsh -NoProfile -File %USERPROFILE%/.config/eilmeldung/get-user.ps1"
```

This is **backward compatible** — existing configs with plain string values for `url` and `user` continue to work unchanged (deserialized as `Secret::Verbatim`). Linux and macOS users can also now use `cmd:` for `url` and `user`.

### 3. Documentation

- `docs/configuration.md`: updated `url`/`user` type to `secret` in the login_setup table; added Windows-specific section explaining `%VAR%` expansion and `pwsh -NoProfile -File` invocation
- `docs/examples/freshrss_secrets_windows.md`: fixed `cmd:` examples to use `pwsh -NoProfile -File`; added gpg shim override instructions for users who have both `git` (bundled MinGW gpg) and `gpg4win` installed via scoop