### PR TITLE
bugfix: creation of duplicates when importing an OPML twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - piping the content through an LLM
   - see `docs/pipe.md` for the full documentation and recipes
   - feel free to contribute your own application scenarios and recipes!
+- bugfix: creation of duplicates when importing an OPML file twice
 
 
 # 1.5.4 - 2026-06-04

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,7 +146,7 @@ pub async fn import_opml(
         ));
     }
     let opml = tokio::fs::read_to_string(path).await?;
-    news_flash.import_opml(&opml, true, client).await?;
+    news_flash.import_opml(&opml, false, client).await?;
     if !cli_args.quiet() {
         termimad::print_text("**done**");
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -379,7 +379,7 @@ impl App {
             }
         };
 
-        self.news_flash_utils.import_opml(opml, true);
+        self.news_flash_utils.import_opml(opml, false);
 
         Ok(())
     }


### PR DESCRIPTION
Thank you for contributing to *eilmeldung*!
# Usage of LLMs/AI

Please indicate if and how you've used LLMs to create the changes:
- [X] no LLMs were used
- [ ] just auto-complete
- [ ] AI-assisted: ~please describe~
- [ ] fully LLM-generated

# Purpose of Changes

bugfix

# Thinks the to Know Before Merging

n/a
