### PR TITLE
fix: ignore horizontal bar when it is not visible (i.e. in zen mode)

### DIFF
--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -70,7 +70,9 @@ impl App {
         match mouse_event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 // Check if clicking on the horizontal border to start a drag-resize
-                if self.panel_areas.is_on_horizontal_border(col, row) {
+                if !matches!(self.state, AppState::ArticleContentDistractionFree)
+                    && self.panel_areas.is_on_horizontal_border(col, row)
+                {
                     self.drag_resize_active = true;
                     return Ok(());
                 }


### PR DESCRIPTION
Thank you for contributing to *eilmeldung*!
# Usage of LLMs/AI

Please indicate if and how you've used LLMs to create the changes:
- [x] no LLMs were used
- [ ] just auto-complete
- [ ] AI-assisted: ~please describe~
- [ ] fully LLM-generated

# Purpose of Changes

Similarly to issue #304 there can be an unintentional mouse interaction with the horizontal line between article list and article content while distraction free (zen) mode is active.
Specifically, it is possible to resize the article list and article content panels by dragging the invisible horizontal bar.

# Thinks the to Know Before Merging

n/a
